### PR TITLE
Selectively turns translation block chaining on and off

### DIFF
--- a/decaf/cpu-exec.c
+++ b/decaf/cpu-exec.c
@@ -560,8 +560,10 @@ int cpu_exec(CPUState *env)
                 /* see if we can patch the calling TB. When the TB
                    spans two pages, we cannot safely do a direct
                    jump. */
-                if (next_tb != 0 && tb->page_addr[1] == -1) {
-                    tb_add_jump((TranslationBlock *)(next_tb & ~3), next_tb & 3, tb);
+                if ((DECAF_tb_chaining == true)){
+                    if (next_tb != 0 && tb->page_addr[1] == -1) {
+                        tb_add_jump((TranslationBlock *)(next_tb & ~3), next_tb & 3, tb);
+                    }
                 }
                 spin_unlock(&tb_lock);
 
@@ -593,13 +595,13 @@ int cpu_exec(CPUState *env)
                             env->icount_extra -= insns_left;
                             env->icount_decr.u16.low = insns_left;
                         } else {
-                            if (insns_left > 0) {
-                                /* Execute remaining instructions.  */
-                                cpu_exec_nocache(env, insns_left, tb);
-                            }
-                            env->exception_index = EXCP_INTERRUPT;
-                            next_tb = 0;
-                            cpu_loop_exit(env);
+                                if (insns_left > 0) {
+                                    /* Execute remaining instructions.  */
+                                    cpu_exec_nocache(env, insns_left, tb);
+                                }
+                                env->exception_index = EXCP_INTERRUPT;
+                                next_tb = 0;
+                                cpu_loop_exit(env);
                         }
                     }
                 }

--- a/decaf/shared/DECAF_main.c
+++ b/decaf/shared/DECAF_main.c
@@ -60,7 +60,7 @@ static int devices=0;
 
 struct __flush_list flush_list_internal;
 
-
+bool DECAF_tb_chaining = true;
 
 
 mon_cmd_t DECAF_mon_cmds[] = {
@@ -765,3 +765,10 @@ void DECAF_bdrv_open(int index, void *opaque) {
   ++devices;
 }
 
+void DECAF_enable_tb_chaining(void) {
+	DECAF_tb_chaining = true;
+}
+
+void DECAF_disable_tb_chaining(void) {
+	DECAF_tb_chaining = false;
+}

--- a/decaf/shared/DECAF_main.h
+++ b/decaf/shared/DECAF_main.h
@@ -249,8 +249,10 @@ void DECAF_flushTranslationCache(int type,target_ulong addr);
 ///send a keystroke into the guest system
 extern void do_send_key(const char *string);
 
-
-
+//Selectively turns translation block chaining on and off
+extern bool DECAF_tb_chaining;
+void DECAF_enable_tb_chaining(void);
+void DECAF_disable_tb_chaining(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
DECAF often fails to handle callback per insn/block due to direct translation block chaining. This patch allows plugin to turn off it.
