### PR TITLE
Fix travis badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
   - Cmd="./configure --enable-vmi --disable-tcg-taint"
   - Cmd="./configure --enable-vmi --enable-tcg-taint"
   - Cmd="./configure --enable-vmi --enable-tcg-taint --enable-tcg-ir-log"
+  - Cmd="./configure --enable-tcg-taint --enable-2nd-ccache --enable-opt-smem"
 
 script:
  - $Cmd && make && make distclean && reset

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Build Status](https://travis-ci.org/sycurelab/DECAF.svg?branch=master)](https://travis-ci.org/sycurelab/DECAF)
+[![Build Status](https://www.travis-ci.com/enlighten5/DECAF.svg?branch=master)](https://www.travis-ci.com/github/enlighten5/DECAF)
 
 ## DECAF
 DECAF (short for Dynamic Executable Code Analysis Framework) is a binary analysis platform based on QEMU. 


### PR DESCRIPTION
The Travis badge had a hyperlink to an old Travis test created by the account sycurelab. Updated it to a hyperlink of my recent Travis build result and it passes. 